### PR TITLE
FT 17701:  Phoenix-5.0.0 HBase-2.0 CDH-6.0.1 

### DIFF
--- a/1
+++ b/1
@@ -3,7 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.apache.phoenix</groupId>
   <artifactId>phoenix</artifactId>
-  <version>5.0.0-HBase-2.0-cdh6.0.1</version>
+  <version>CDH-6.0.1-HBase-2.0-SNAPSHOT</version>
   <packaging>pom</packaging>
   <name>Apache Phoenix</name>
   <description>A SQL layer over HBase</description>
@@ -37,7 +37,6 @@
     <module>phoenix-assembly</module>
     <module>phoenix-tracing-webapp</module>
     <module>phoenix-load-balancer</module>
-    <module>phoenix-parcel</module>
   </modules>
 
   <repositories>
@@ -49,15 +48,6 @@
       <id>cloudera</id>
       <url>https://repository.cloudera.com/artifactory/cloudera-repos/</url>
     </repository>
-    <repository>
-      <id>cdh.releases.repo</id>
-      <url>https://repository.cloudera.com/content/groups/cdh-releases-rcs</url>
-      <name>CDH Releases Repository</name>
-      <snapshots>
-        <enabled>false</enabled>
-      </snapshots>
-    </repository>
-
   </repositories>
 
   <parent>
@@ -85,39 +75,37 @@
 
     <!-- Dependency versions -->
     <commons-cli.version>1.4</commons-cli.version>
-    <!--BROKEN <hive.version>2.1.1-cdh6.0.1</hive.version>-->
     <hive.version>3.0.0</hive.version>
-    <!--BROKEN <pig.version>0.17.0-cdh6.0.1</pig.version>-->
     <pig.version>0.13.0</pig.version>
-    <jackson.version>1.9.13</jackson.version>
+    <jackson.version>1.9.2</jackson.version>
     <antlr.version>3.5.2</antlr.version>
     <log4j.version>1.2.17</log4j.version>
     <disruptor.version>3.3.6</disruptor.version>
-    <slf4j.version>1.7.25</slf4j.version>
+    <slf4j.version>1.6.4</slf4j.version>
     <protobuf-java.version>2.5.0</protobuf-java.version>
-    <commons-io.version>2.6</commons-io.version>
-    <commons-lang.version>2.6</commons-lang.version>
+    <commons-io.version>2.1</commons-io.version>
+    <commons-lang.version>3.8</commons-lang.version>
     <commons-logging.version>1.2</commons-logging.version>
     <commons-csv.version>1.0</commons-csv.version>
     <sqlline.version>1.2.0</sqlline.version>
     <guava.version>13.0.1</guava.version>
-    <flume.version>1.8.0-cdh6.0.1</flume.version>
-    <!--BROKEN <kafka.version>1.0.1-cdh6.0.1</kafka.version>-->
+    <flume.version>1.4.0</flume.version>
     <kafka.version>0.9.0.0</kafka.version>
     <findbugs-annotations.version>1.3.9-1</findbugs-annotations.version>
     <jcip-annotations.version>1.0-1</jcip-annotations.version>
     <jline.version>2.11</jline.version>
     <snappy.version>0.3</snappy.version>
-    <commons-codec.version>1.9</commons-codec.version>
+    <commons-codec.version>1.7</commons-codec.version>
     <htrace.version>3.1.0-incubating</htrace.version>
     <collections.version>3.2.2</collections.version>
     <!-- Do not change jodatime.version until HBASE-15199 is fixed -->
     <jodatime.version>1.6</jodatime.version>
     <joni.version>2.1.2</joni.version>
-    <avatica.version>1.11.0</avatica.version>
+    <avatica.version>1.12.0</avatica.version>
     <jetty.version>9.3.19.v20170502</jetty.version>
-    <tephra.version>0.14.0-incubating</tephra.version>
-    <spark.version>2.2.0-cdh6.0.1</spark.version>
+    <tephra.version>0.15.0-incubating</tephra.version>
+    <omid.version>1.0.0</omid.version>
+    <spark.version>2.3.0</spark.version>
     <scala.version>2.11.8</scala.version>
     <scala.binary.version>2.11</scala.binary.version>
     <stream.version>2.9.5</stream.version>
@@ -139,7 +127,7 @@
 
     <!-- Plugin options -->
     <numForkedUT>8</numForkedUT>
-    <numForkedIT>4</numForkedIT>
+    <numForkedIT>7</numForkedIT>
     <it.failIfNoSpecifiedTests>false</it.failIfNoSpecifiedTests>
     <surefire.failIfNoSpecifiedTests>false</surefire.failIfNoSpecifiedTests>
 
@@ -377,7 +365,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-shade-plugin</artifactId>
-          <version>2.4.3</version>
+          <version>3.1.1</version>
         </plugin>
         <plugin>
           <!-- Allows us to get the apache-ds bundle artifacts -->
@@ -477,16 +465,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-site-plugin</artifactId>
-        <version>3.2</version>
-        <configuration>
-          <reportPlugins>
-            <plugin>
-              <groupId>org.codehaus.mojo</groupId>
-              <artifactId>findbugs-maven-plugin</artifactId>
-              <version>2.5.2</version>
-            </plugin>
-          </reportPlugins>
-        </configuration>
+        <version>3.7.1</version>
       </plugin>
       <plugin>
         <groupId>org.apache.rat</groupId>
@@ -512,12 +491,14 @@
             <!-- Argparse is bundled to work around system Python version
                  issues, compatibile with ALv2 -->
             <exclude>bin/argparse-1.4.0/argparse.py</exclude>
-            <exclude>python/ci/**</exclude>
-            <exclude>python/phoenixdb/avatica/proto/*</exclude>
-            <exclude>python/*.rst</exclude>
-            <exclude>python/doc/*.rst</exclude>
-            <exclude>python/doc/conf.py</exclude>
-            <exclude>python/doc/Makefile</exclude>
+            <!-- Not our code -->
+            <exclude>python/requests-kerberos/**</exclude>
+            <exclude>python/phoenixdb/phoenixdb/avatica/proto/*</exclude>
+            <exclude>python/phoenixdb/*.rst</exclude>
+            <exclude>python/phoenixdb/ci/**</exclude>
+            <exclude>python/phoenixdb/doc/*.rst</exclude>
+            <exclude>python/phoenixdb/doc/conf.py</exclude>
+            <exclude>python/phoenixdb/doc/Makefile</exclude>
           </excludes>
         </configuration>
       </plugin>
@@ -534,6 +515,11 @@
   <dependencyManagement>
     <dependencies>
       <!-- Intra-project dependencies -->
+      <dependency>
+        <groupId>org.apache.hadoop</groupId>
+        <artifactId>hadoop-common</artifactId>
+        <version>${hadoop.version}</version>
+      </dependency>
       <dependency>
         <groupId>org.apache.phoenix</groupId>
         <artifactId>phoenix-core</artifactId>
@@ -583,13 +569,6 @@
       </dependency>
 
       <!-- HBase dependencies -->
-      <!-- Failed to read artifact descriptor for org.glassfish:javax.el:jar:3.0.1-b06-SNAPSHOT -->
-      <!--<dependency>-->
-        <!--<groupId>org.glassfish</groupId>-->
-        <!--<artifactId>javax.el</artifactId>-->
-        <!--<version>3.0.1-b10</version>-->
-        <!--<scope>provided</scope>-->
-      <!--</dependency>-->
       <dependency>
         <groupId>org.apache.hbase</groupId>
         <artifactId>hbase-annotations</artifactId>
@@ -978,6 +957,11 @@
         <version>${commons-csv.version}</version>
       </dependency>
       <dependency>
+        <groupId>org.apache.commons</groupId>
+        <artifactId>commons-lang3</artifactId>
+        <version>${commons-lang.version}</version>
+      </dependency>
+      <dependency>
         <groupId>joda-time</groupId>
         <artifactId>joda-time</artifactId>
         <version>${jodatime.version}</version>
@@ -1085,4 +1069,19 @@
       </properties>
     </profile>
   </profiles>
+
+  <reporting>
+      <plugins>
+          <plugin>
+              <groupId>org.apache.maven.plugins</groupId>
+              <artifactId>maven-project-info-reports-plugin</artifactId>
+              <version>3.0.0</version>
+          </plugin>
+          <plugin>
+              <groupId>org.codehaus.mojo</groupId>
+              <artifactId>findbugs-maven-plugin</artifactId>
+              <version>3.0.5</version>
+          </plugin>
+      </plugins>
+  </reporting>
 </project>

--- a/phoenix-assembly/pom.xml
+++ b/phoenix-assembly/pom.xml
@@ -27,7 +27,7 @@
   <parent>
     <groupId>org.apache.phoenix</groupId>
     <artifactId>phoenix</artifactId>
-    <version>5.0.0-HBase-2.0</version>
+    <version>5.0.0-HBase-2.0-cdh6.0.1</version>
   </parent>
   <artifactId>phoenix-assembly</artifactId>
   <name>Phoenix Assembly</name>

--- a/phoenix-client/pom.xml
+++ b/phoenix-client/pom.xml
@@ -27,7 +27,7 @@
   <parent>
     <groupId>org.apache.phoenix</groupId>
     <artifactId>phoenix</artifactId>
-    <version>5.0.0-HBase-2.0</version>
+    <version>5.0.0-HBase-2.0-cdh6.0.1</version>
   </parent>
   <artifactId>phoenix-client</artifactId>
   <name>Phoenix Client</name>

--- a/phoenix-core/pom.xml
+++ b/phoenix-core/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.apache.phoenix</groupId>
     <artifactId>phoenix</artifactId>
-    <version>5.0.0-HBase-2.0</version>
+    <version>5.0.0-HBase-2.0-cdh6.0.1</version>
   </parent>
   <artifactId>phoenix-core</artifactId>
   <name>Phoenix Core</name>
@@ -385,6 +385,10 @@
         <exclusion>
           <groupId>xom</groupId>
           <artifactId>xom</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.glassfish</groupId>
+          <artifactId>javax.el</artifactId>
         </exclusion>
       </exclusions>
     </dependency>

--- a/phoenix-core/src/main/java/org/apache/phoenix/hbase/index/covered/data/DelegateComparator.java
+++ b/phoenix-core/src/main/java/org/apache/phoenix/hbase/index/covered/data/DelegateComparator.java
@@ -1,0 +1,83 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.phoenix.hbase.index.covered.data;
+
+import java.util.Comparator;
+
+import org.apache.hadoop.hbase.Cell;
+import org.apache.hadoop.hbase.CellComparator;
+
+public class DelegateComparator implements CellComparator {
+    
+    private CellComparator delegate;
+
+    public DelegateComparator(CellComparator delegate) {
+        this.delegate=delegate;
+    }
+
+    @Override
+    public int compare(Cell leftCell, Cell rightCell) {
+        return delegate.compare(leftCell, rightCell);
+    }
+
+    @Override
+    public int compareRows(Cell leftCell, Cell rightCell) {
+        return delegate.compareRows(leftCell, rightCell);
+    }
+
+    @Override
+    public int compareRows(Cell cell, byte[] bytes, int offset, int length) {
+        return delegate.compareRows(cell, bytes, offset, length);
+    }
+
+    @Override
+    public int compareWithoutRow(Cell leftCell, Cell rightCell) {
+        return delegate.compareWithoutRow(leftCell, rightCell);
+    }
+
+    @Override
+    public int compareFamilies(Cell leftCell, Cell rightCell) {
+        return delegate.compareFamilies(leftCell, rightCell);
+    }
+
+    @Override
+    public int compareQualifiers(Cell leftCell, Cell rightCell) {
+        return delegate.compareQualifiers(leftCell, rightCell);
+    }
+
+    @Override
+    public int compareTimestamps(Cell leftCell, Cell rightCell) {
+        return delegate.compareTimestamps(leftCell, rightCell);
+    }
+
+    @Override
+    public int compareTimestamps(long leftCellts, long rightCellts) {
+        return delegate.compareTimestamps(leftCellts, rightCellts);
+    }
+
+    @Override
+    public int compare(Cell leftCell, Cell rightCell, boolean ignoreSequenceid) {
+        return delegate.compare(leftCell, rightCell, ignoreSequenceid);
+    }
+
+    @Override
+    public Comparator getSimpleComparator() {
+        return delegate.getSimpleComparator();
+    }
+
+}

--- a/phoenix-core/src/main/java/org/apache/phoenix/hbase/index/covered/data/IndexMemStore.java
+++ b/phoenix-core/src/main/java/org/apache/phoenix/hbase/index/covered/data/IndexMemStore.java
@@ -79,10 +79,10 @@ public class IndexMemStore implements KeyValueStore {
   private CellComparator comparator;
 
   public IndexMemStore() {
-    this(new CellComparatorImpl(){
+    this(new DelegateComparator(new CellComparatorImpl()){
         @Override
-        public int compare(Cell a, Cell b) {
-            return super.compare(a, b, true);
+        public int compare(Cell leftCell, Cell rightCell) {
+            return super.compare(leftCell, rightCell, true);
         }
     });
   }

--- a/phoenix-core/src/test/java/org/apache/phoenix/hbase/index/covered/data/TestIndexMemStore.java
+++ b/phoenix-core/src/test/java/org/apache/phoenix/hbase/index/covered/data/TestIndexMemStore.java
@@ -39,10 +39,10 @@ public class TestIndexMemStore {
 
   @Test
   public void testCorrectOverwritting() throws Exception {
-    IndexMemStore store = new IndexMemStore(new CellComparatorImpl(){
+    IndexMemStore store = new IndexMemStore(new DelegateComparator(new CellComparatorImpl()){
         @Override
-        public int compare(Cell a, Cell b) {
-            return super.compare(a, b, true);
+        public int compare(Cell leftCell, Cell rightCell) {
+            return super.compare(leftCell, rightCell, true);
         }
     });
     long ts = 10;

--- a/phoenix-flume/pom.xml
+++ b/phoenix-flume/pom.xml
@@ -26,7 +26,7 @@
   <parent>
     <groupId>org.apache.phoenix</groupId>
     <artifactId>phoenix</artifactId>
-    <version>5.0.0-HBase-2.0</version>
+    <version>5.0.0-HBase-2.0-cdh6.0.1</version>
   </parent>
   <artifactId>phoenix-flume</artifactId>
   <name>Phoenix - Flume</name>

--- a/phoenix-hive/pom.xml
+++ b/phoenix-hive/pom.xml
@@ -27,7 +27,7 @@
   <parent>
     <groupId>org.apache.phoenix</groupId>
     <artifactId>phoenix</artifactId>
-    <version>5.0.0-HBase-2.0</version>
+    <version>5.0.0-HBase-2.0-cdh6.0.1</version>
   </parent>
   <artifactId>phoenix-hive</artifactId>
   <name>Phoenix - Hive</name>

--- a/phoenix-kafka/pom.xml
+++ b/phoenix-kafka/pom.xml
@@ -26,7 +26,7 @@
 	<parent>
 		<groupId>org.apache.phoenix</groupId>
 		<artifactId>phoenix</artifactId>
-		<version>5.0.0-HBase-2.0</version>
+		<version>5.0.0-HBase-2.0-cdh6.0.1</version>
 	</parent>
 	<artifactId>phoenix-kafka</artifactId>
 	<name>Phoenix - Kafka</name>

--- a/phoenix-load-balancer/pom.xml
+++ b/phoenix-load-balancer/pom.xml
@@ -27,7 +27,7 @@
   <parent>
     <groupId>org.apache.phoenix</groupId>
     <artifactId>phoenix</artifactId>
-    <version>5.0.0-HBase-2.0</version>
+    <version>5.0.0-HBase-2.0-cdh6.0.1</version>
   </parent>
   <artifactId>phoenix-load-balancer</artifactId>
   <name>Phoenix Load Balancer</name>

--- a/phoenix-parcel/pom.xml
+++ b/phoenix-parcel/pom.xml
@@ -1,0 +1,279 @@
+<?xml version='1.0'?>
+<!--
+
+ Licensed to the Apache Software Foundation (ASF) under one
+ or more contributor license agreements.  See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership.  The ASF licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+
+-->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>org.apache.phoenix</groupId>
+    <artifactId>phoenix</artifactId>
+    <version>5.0.0-HBase-2.0-cdh6.0.1</version>
+  </parent>
+  <artifactId>phoenix-parcel</artifactId>
+  <name>Phoenix Parcels for CDH</name>
+  <description>Assemble Phoenix artifacts for CDH</description>
+  <packaging>pom</packaging>
+
+  <properties>
+    <source.skip>true</source.skip>
+    <top.dir>${project.basedir}/..</top.dir>
+    <maven.test.skip>true</maven.test.skip>
+    <phoenix.version>${project.version}</phoenix.version>
+    <parcel.patch.count>0</parcel.patch.count>
+    <parcel.release>1.${parcel.patch.count}</parcel.release>
+    <parcel.folder>APACHE_PHOENIX-${phoenix.version}.p${parcel.release}</parcel.folder>
+    <parcel.file>${parcel.folder}.parcel</parcel.file>
+    <parcel.version>${phoenix.version}.p${parcel.release}</parcel.version>
+    <parcel.base.version>${phoenix.version}</parcel.base.version>
+    <parcel.full.version>${phoenix.version}.p${parcel.release}</parcel.full.version>
+    <parcel.package.version>${phoenix.version}+${parcel.patch.count}</parcel.package.version>
+    <parcel.component.version>${phoenix.version}</parcel.component.version>
+    <parcel.component.release>${cdh.version}.p${parcel.release}</parcel.component.release>
+  </properties>
+
+  <build>
+    <plugins>
+      <!-- No jars created for this module -->
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-jar-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>default-jar</id>
+            <phase>none</phase>
+            <goals/>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <artifactId>maven-assembly-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>prepare-parcel</id>
+            <phase>prepare-package</phase>
+            <goals>
+              <goal>single</goal>
+            </goals>
+            <configuration>
+              <finalName>${parcel.file}</finalName>
+              <attach>false</attach>
+              <tarLongFileMode>gnu</tarLongFileMode>
+              <appendAssemblyId>false</appendAssemblyId>
+              <descriptors>
+                <descriptor>src/build/parcel.xml</descriptor>
+              </descriptors>
+              <tarLongFileMode>posix</tarLongFileMode>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>com.coderplus.maven.plugins</groupId>
+        <artifactId>copy-rename-maven-plugin</artifactId>
+        <version>1.0.1</version>
+        <executions>
+          <execution>
+            <id>copy-file-el6</id>
+            <phase>package</phase>
+            <goals>
+              <goal>copy</goal>
+            </goals>
+            <configuration>
+              <sourceFile>${project.build.directory}/${parcel.folder}.parcel.tar</sourceFile>
+              <destinationFile>${project.build.directory}/${parcel.folder}-el6.parcel</destinationFile>
+            </configuration>
+          </execution>
+          <execution>
+            <id>copy-file-el5</id>
+            <phase>package</phase>
+            <goals>
+              <goal>copy</goal>
+            </goals>
+            <configuration>
+              <sourceFile>${project.build.directory}/${parcel.folder}.parcel.tar</sourceFile>
+              <destinationFile>${project.build.directory}/${parcel.folder}-el5.parcel</destinationFile>
+            </configuration>
+          </execution>
+          <execution>
+            <id>copy-file-el7</id>
+            <phase>package</phase>
+            <goals>
+              <goal>copy</goal>
+            </goals>
+            <configuration>
+              <sourceFile>${project.build.directory}/${parcel.folder}.parcel.tar</sourceFile>
+              <destinationFile>${project.build.directory}/${parcel.folder}-el7.parcel</destinationFile>
+            </configuration>
+          </execution>
+          <execution>
+            <id>copy-file-sles11</id>
+            <phase>package</phase>
+            <goals>
+              <goal>copy</goal>
+            </goals>
+            <configuration>
+              <sourceFile>${project.build.directory}/${parcel.folder}.parcel.tar</sourceFile>
+              <destinationFile>${project.build.directory}/${parcel.folder}-sles11.parcel</destinationFile>
+            </configuration>
+          </execution>
+          <execution>
+            <id>copy-file-sles12</id>
+            <phase>package</phase>
+            <goals>
+              <goal>copy</goal>
+            </goals>
+            <configuration>
+              <sourceFile>${project.build.directory}/${parcel.folder}.parcel.tar</sourceFile>
+              <destinationFile>${project.build.directory}/${parcel.folder}-sles12.parcel</destinationFile>
+            </configuration>
+          </execution>
+          <execution>
+            <id>copy-file-precise</id>
+            <phase>package</phase>
+            <goals>
+              <goal>copy</goal>
+            </goals>
+            <configuration>
+              <sourceFile>${project.build.directory}/${parcel.folder}.parcel.tar</sourceFile>
+              <destinationFile>${project.build.directory}/${parcel.folder}-precise.parcel</destinationFile>
+            </configuration>
+          </execution>
+          <execution>
+            <id>copy-file-jessie</id>
+            <phase>package</phase>
+            <goals>
+              <goal>copy</goal>
+            </goals>
+            <configuration>
+              <sourceFile>${project.build.directory}/${parcel.folder}.parcel.tar</sourceFile>
+              <destinationFile>${project.build.directory}/${parcel.folder}-jessie.parcel</destinationFile>
+            </configuration>
+          </execution>
+          <execution>
+            <id>copy-file-trusty</id>
+            <phase>package</phase>
+            <goals>
+              <goal>copy</goal>
+            </goals>
+            <configuration>
+              <sourceFile>${project.build.directory}/${parcel.folder}.parcel.tar</sourceFile>
+              <destinationFile>${project.build.directory}/${parcel.folder}-trusty.parcel</destinationFile>
+            </configuration>
+          </execution>
+          <execution>
+            <id>copy-file-wheezy</id>
+            <phase>package</phase>
+            <goals>
+              <goal>copy</goal>
+            </goals>
+            <configuration>
+              <sourceFile>${project.build.directory}/${parcel.folder}.parcel.tar</sourceFile>
+              <destinationFile>${project.build.directory}/${parcel.folder}-wheezy.parcel</destinationFile>
+            </configuration>
+          </execution>
+          <execution>
+            <id>copy-file-xenial</id>
+            <phase>package</phase>
+            <goals>
+              <goal>copy</goal>
+            </goals>
+            <configuration>
+              <sourceFile>${project.build.directory}/${parcel.folder}.parcel.tar</sourceFile>
+              <destinationFile>${project.build.directory}/${parcel.folder}-xenial.parcel</destinationFile>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>exec-maven-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>make-manifest</id>
+            <phase>package</phase>
+            <goals>
+              <goal>exec</goal>
+            </goals>
+          </execution>
+        </executions>
+        <configuration>
+          <executable>python</executable>
+          <workingDirectory>${project.build.directory}</workingDirectory>
+          <arguments>
+            <argument>${project.basedir}/src/build/manifest/make_manifest.py</argument>
+            <argument>${project.build.directory}</argument>
+          </arguments>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>com.coderplus.maven.plugins</groupId>
+        <artifactId>copy-rename-maven-plugin</artifactId>
+        <version>1.0.1</version>
+        <executions>
+          <execution>
+            <id>copy-file-el6</id>
+            <phase>package</phase>
+            <goals>
+              <goal>copy</goal>
+            </goals>
+            <configuration>
+              <sourceFile>${project.build.directory}/${parcel.folder}.parcel.tar</sourceFile>
+              <destinationFile>${project.build.directory}/${parcel.folder}-el6.parcel</destinationFile>
+            </configuration>
+          </execution>
+          <execution>
+            <id>copy-file-el7</id>
+            <phase>package</phase>
+            <goals>
+              <goal>copy</goal>
+            </goals>
+            <configuration>
+              <sourceFile>${project.build.directory}/${parcel.folder}.parcel.tar</sourceFile>
+              <destinationFile>${project.build.directory}/${parcel.folder}-el7.parcel</destinationFile>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+
+  <dependencies>
+    <!-- Depend on all other internal projects -->
+    <dependency>
+      <groupId>org.apache.phoenix</groupId>
+      <artifactId>phoenix-core</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.phoenix</groupId>
+      <artifactId>phoenix-flume</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.phoenix</groupId>
+      <artifactId>phoenix-pig</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.phoenix</groupId>
+      <artifactId>phoenix-spark</artifactId>
+    </dependency>
+  </dependencies>
+</project>

--- a/phoenix-parcel/src/build/components/all-common-dependencies.xml
+++ b/phoenix-parcel/src/build/components/all-common-dependencies.xml
@@ -1,0 +1,56 @@
+<?xml version='1.0'?>
+<!--
+
+ Licensed to the Apache Software Foundation (ASF) under one
+ or more contributor license agreements.  See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership.  The ASF licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+
+-->
+<component>
+  <!-- All of our dependencies -->
+  <dependencySets>
+    <dependencySet>
+      <unpack>false</unpack>
+      <outputDirectory>${parcel.folder}/lib/phoenix/lib</outputDirectory>
+      <includes>
+        <include>org.apache.phoenix:phoenix-core</include>
+        <include>org.iq80.snappy:snappy</include>
+        <include>org.antlr:antlr*</include>
+        <include>org.apache.tephra:tephra*</include>
+        <include>com.google.code.gson:gson</include>
+        <include>org.jruby.joni:joni</include>
+        <include>org.jruby.jcodings:jcodings</include>
+        <include>joda-time:joda-time</include>
+        <include>org.apache.twill:twill*</include>
+        <include>com.google.inject.extensions:guice-assistedinject</include>
+        <include>it.unimi.dsi:fastutil</include>
+        <include>io.dropwizard.metrics:metrics-core</include>
+        <include>org.apache.thrift:libthrift</include>
+        <include>com.clearspring.analytics:stream</include>
+        <include>com.salesforce.i18n:i18n-util</include>
+        <include>com.tdunning:json</include>
+        <include>com.jayway.jsonpath:json-path</include>
+        <include>net.minidev:json-smart</include>
+        <include>net.minidev:accessors-smart</include>
+        <include>sqlline:sqlline</include>
+        <include>org.apache.commons:commons-csv</include>
+        <include>com.ibm.icu:icu4j</include>
+        <include>com.ibm.icu:icu4j-charset</include>
+        <include>com.ibm.icu:icu4j-localespi</include>
+      </includes>
+    </dependencySet>
+  </dependencySets>
+</component>

--- a/phoenix-parcel/src/build/components/all-common-files.xml
+++ b/phoenix-parcel/src/build/components/all-common-files.xml
@@ -1,0 +1,84 @@
+<?xml version='1.0'?>
+<!--
+
+ Licensed to the Apache Software Foundation (ASF) under one
+ or more contributor license agreements.  See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership.  The ASF licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+
+-->
+<component>
+
+  <fileSets>
+
+    <!-- Executable files from bin directory  -->
+    <fileSet>
+      <directory>${project.basedir}/src/parcel/bin</directory>
+      <outputDirectory>${parcel.folder}/bin</outputDirectory>
+      <fileMode>0755</fileMode>
+      <directoryMode>0755</directoryMode>
+      <filtered>false</filtered>
+      <includes>
+        <include>*</include>
+      </includes>
+    </fileSet>
+    <!-- Meta files -->
+    <fileSet>
+      <directory>${project.basedir}/src/parcel/meta</directory>
+      <outputDirectory>${parcel.folder}/meta</outputDirectory>
+      <fileMode>0644</fileMode>
+      <directoryMode>0755</directoryMode>
+      <filtered>true</filtered>
+      <includes>
+        <include>*</include>
+      </includes>
+    </fileSet>
+
+    <!-- lib/bin files -->
+    <fileSet>
+      <directory>${project.basedir}/../bin</directory>
+      <outputDirectory>${parcel.folder}/lib/phoenix/bin</outputDirectory>
+      <fileMode>0755</fileMode>
+      <directoryMode>0755</directoryMode>
+      <filtered>false</filtered>
+      <excludes>
+        <exclude>hbase-site.xml</exclude>
+      </excludes>
+    </fileSet>
+    <!-- lib/dev files -->
+    <fileSet>
+      <directory>${project.basedir}/../dev</directory>
+      <outputDirectory>${parcel.folder}/lib/phoenix/dev</outputDirectory>
+      <fileMode>0644</fileMode>
+      <directoryMode>0755</directoryMode>
+      <filtered>false</filtered>
+      <includes>
+        <include>*</include>
+      </includes>
+    </fileSet>
+    <!-- lib/examples files -->
+    <fileSet>
+      <directory>${project.basedir}/../examples</directory>
+      <outputDirectory>${parcel.folder}/lib/phoenix/examples</outputDirectory>
+      <fileMode>0644</fileMode>
+      <directoryMode>0755</directoryMode>
+      <filtered>false</filtered>
+      <includes>
+        <include>*</include>
+      </includes>
+    </fileSet>
+
+  </fileSets>
+</component>

--- a/phoenix-parcel/src/build/components/all-common-jars.xml
+++ b/phoenix-parcel/src/build/components/all-common-jars.xml
@@ -1,0 +1,217 @@
+<?xml version='1.0'?>
+<!--
+
+ Licensed to the Apache Software Foundation (ASF) under one
+ or more contributor license agreements.  See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership.  The ASF licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+
+-->
+<component>
+  <fileSets>
+     <!-- Add the client & mapreduce jars. Expects the client jar packaging phase to already be run,
+      which is determined by specification order in the pom. -->
+    <fileSet>
+      <directory>${project.basedir}/../phoenix-client/target</directory>
+      <outputDirectory>${parcel.folder}/lib/phoenix/</outputDirectory>
+      <includes>
+        <include>phoenix-*-client.jar</include>
+      </includes>
+      <excludes>
+        <exclude>*-minimal.jar</exclude>
+        <exclude>*-sources.jar</exclude>
+        <exclude>*-tests.jar</exclude>
+      </excludes>
+      <fileMode>0644</fileMode>
+    </fileSet>
+    <fileSet>
+      <directory>${project.basedir}/../phoenix-server/target</directory>
+      <outputDirectory>${parcel.folder}/lib/phoenix/</outputDirectory>
+      <includes>
+        <include>phoenix-*-server.jar</include>
+      </includes>
+      <excludes>
+        <exclude>*-minimal.jar</exclude>
+        <exclude>*-sources.jar</exclude>
+        <exclude>*-tests.jar</exclude>
+      </excludes>
+      <fileMode>0644</fileMode>
+    </fileSet>
+    <fileSet>
+      <directory>${project.basedir}/../phoenix-queryserver/target/</directory>
+      <outputDirectory>${parcel.folder}/lib/phoenix/</outputDirectory>
+      <includes>
+        <include>phoenix-*-queryserver.jar</include>
+      </includes>
+      <excludes>
+        <exclude>*-minimal.jar</exclude>
+        <exclude>*-sources.jar</exclude>
+        <exclude>*-tests.jar</exclude>
+      </excludes>
+      <fileMode>0644</fileMode>
+    </fileSet>
+    <fileSet>
+      <directory>${project.basedir}/../phoenix-queryserver-client/target/</directory>
+      <outputDirectory>${parcel.folder}/lib/phoenix/</outputDirectory>
+      <includes>
+        <include>phoenix-*-thin-client.jar</include>
+      </includes>
+      <excludes>
+        <exclude>*-minimal.jar</exclude>
+        <exclude>*-sources.jar</exclude>
+        <exclude>*-tests.jar</exclude>
+      </excludes>
+      <fileMode>0644</fileMode>
+    </fileSet>
+    <fileSet>
+      <directory>${project.basedir}/../phoenix-hive/target/</directory>
+      <outputDirectory>${parcel.folder}/lib/phoenix/</outputDirectory>
+      <includes>
+        <include>phoenix-*-hive.jar</include>
+      </includes>
+      <excludes>
+        <exclude>*-minimal.jar</exclude>
+        <exclude>*-sources.jar</exclude>
+        <exclude>*-tests.jar</exclude>
+      </excludes>
+      <fileMode>0644</fileMode>
+    </fileSet>
+
+    <!-- This is only necessary until maven fixes the intra-project dependency bug
+      in maven 3.0. Until then, we have to include the jars for sub-projects explicitly.
+      Otherwise, test jars are pulled in wrongly.
+     -->
+    <fileSet>
+      <directory>${project.basedir}/../phoenix-hadoop-compat/target/</directory>
+      <outputDirectory>${parcel.folder}/lib/phoenix/lib</outputDirectory>
+      <includes>
+        <include>phoenix-*.jar</include>
+      </includes>
+      <excludes>
+        <exclude>*-minimal.jar</exclude>
+        <exclude>*-sources.jar</exclude>
+        <exclude>*-tests.jar</exclude>
+      </excludes>
+      <fileMode>0644</fileMode>
+    </fileSet>
+    <fileSet>
+      <directory>${project.basedir}/../phoenix-pig/target/</directory>
+      <outputDirectory>${parcel.folder}/lib/phoenix/lib</outputDirectory>
+      <includes>
+        <include>phoenix-pig-*.jar</include>
+      </includes>
+      <excludes>
+        <exclude>*-minimal.jar</exclude>
+        <exclude>*-sources.jar</exclude>
+        <exclude>*-tests.jar</exclude>
+      </excludes>
+      <fileMode>0644</fileMode>
+    </fileSet>
+    <fileSet>
+      <directory>${project.basedir}/../phoenix-flume/target/</directory>
+      <outputDirectory>${parcel.folder}/lib/phoenix/lib</outputDirectory>
+      <includes>
+        <include>phoenix-*.jar</include>
+      </includes>
+      <excludes>
+        <exclude>*-minimal.jar</exclude>
+        <exclude>*-sources.jar</exclude>
+        <exclude>*-tests.jar</exclude>
+      </excludes>
+      <fileMode>0644</fileMode>
+    </fileSet>
+    <fileSet>
+      <directory>${project.basedir}/../phoenix-core/target/</directory>
+      <outputDirectory>${parcel.folder}/lib/phoenix/lib</outputDirectory>
+      <includes>
+        <include>phoenix-*.jar</include>
+      </includes>
+      <excludes>
+        <exclude>*-minimal.jar</exclude>
+        <exclude>*-sources.jar</exclude>
+        <exclude>*-tests.jar</exclude>
+      </excludes>
+      <fileMode>0644</fileMode>
+    </fileSet>
+    <fileSet>
+      <directory>${project.basedir}/../phoenix-spark/target/</directory>
+      <outputDirectory>${parcel.folder}/lib/phoenix/lib</outputDirectory>
+      <includes>
+          <include>phoenix-*.jar</include>
+      </includes>
+      <excludes>
+        <exclude>*-javadoc.jar</exclude>
+        <exclude>*-minimal.jar</exclude>
+        <exclude>*-sources.jar</exclude>
+        <exclude>*-tests.jar</exclude>
+      </excludes>
+      <fileMode>0644</fileMode>
+    </fileSet>
+    <fileSet>
+      <directory>${project.basedir}/../phoenix-queryserver/target/</directory>
+      <outputDirectory>${parcel.folder}/lib/phoenix/lib</outputDirectory>
+      <includes>
+        <include>phoenix-queryserver-*.jar</include>
+      </includes>
+      <excludes>
+        <exclude>*-minimal.jar</exclude>
+        <exclude>*-sources.jar</exclude>
+        <exclude>*-tests.jar</exclude>
+      </excludes>
+      <fileMode>0644</fileMode>
+    </fileSet>
+    <fileSet>
+      <directory>${project.basedir}/../phoenix-hive/target/</directory>
+      <outputDirectory>${parcel.folder}/lib/phoenix/lib</outputDirectory>
+      <includes>
+        <include>phoenix-hive-*.jar</include>
+      </includes>
+      <excludes>
+        <exclude>*-minimal.jar</exclude>
+        <exclude>*-sources.jar</exclude>
+        <exclude>*-tests.jar</exclude>
+      </excludes>
+      <fileMode>0644</fileMode>
+    </fileSet>
+    <fileSet>
+      <directory>${project.basedir}/../phoenix-queryserver-client/target/</directory>
+      <outputDirectory>${parcel.folder}/lib/phoenix/lib</outputDirectory>
+      <includes>
+        <include>phoenix-*.jar</include>
+      </includes>
+      <excludes>
+        <exclude>*-minimal.jar</exclude>
+        <exclude>*-sources.jar</exclude>
+        <exclude>*-tests.jar</exclude>
+        <!-- this one goes in project root instead -->
+        <exclude>phoenix-*-thin-client.jar</exclude>
+      </excludes>
+      <fileMode>0644</fileMode>
+    </fileSet>
+    <fileSet>
+      <directory>${project.basedir}/../phoenix-pherf/target/</directory>
+      <outputDirectory>${parcel.folder}/lib/phoenix/lib</outputDirectory>
+      <includes>
+        <include>phoenix-*.jar</include>
+      </includes>
+      <excludes>
+        <exclude>*-minimal.jar</exclude>
+        <exclude>*-sources.jar</exclude>
+        <exclude>*-tests.jar</exclude>
+      </excludes>
+      <fileMode>0644</fileMode>
+    </fileSet>
+  </fileSets>
+</component>

--- a/phoenix-parcel/src/build/manifest/make_manifest.py
+++ b/phoenix-parcel/src/build/manifest/make_manifest.py
@@ -1,0 +1,117 @@
+#!/usr/bin/env python
+#
+# Licensed to Cloudera, Inc. under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  Cloudera, Inc. licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This program creates a manifest.json file from a directory of parcels and
+# places the file in the same directory as the parcels.
+# Once created, the directory can be served over http as a parcel repository.
+
+import hashlib
+import json
+import os
+import re
+import sys
+import tarfile
+import time
+
+def _get_parcel_dirname(parcel_name):
+  """
+  Extract the required parcel directory name for a given parcel.
+
+  eg: CDH-5.0.0-el6.parcel -> CDH-5.0.0
+  """
+  parts = re.match(r"^(.*?)-(.*)-(.*?)$", parcel_name).groups()
+  return parts[0] + '-' + parts[1]
+
+def _safe_copy(key, src, dest):
+  """
+  Conditionally copy a key/value pair from one dictionary to another.
+
+  Nothing is done if the key is not present in the source dictionary
+  """
+  if key in src:
+    dest[key] = src[key]
+
+def make_manifest(path, timestamp=time.time()):
+  """
+  Make a manifest.json document from the contents of a directory.
+
+  This function will scan the specified directory, identify any parcel files
+  in it, and then build a manifest from those files. Certain metadata will be
+  extracted from the parcel and copied into the manifest.
+
+  @param path: The path of the directory to scan for parcels
+  @param timestamp: Unix timestamp to place in manifest.json
+  @return: the manifest.json as a string
+  """
+  manifest = {}
+  manifest['lastUpdated'] = int(timestamp * 1000)
+  manifest['parcels'] = []
+
+  files = os.listdir(path)
+  for f in files:
+    if not f.endswith('.parcel'):
+      continue
+
+    print("Found parcel %s" % (f,))
+    entry = {}
+    entry['parcelName'] = f
+
+    fullpath = os.path.join(path, f)
+
+    with open(fullpath, 'rb') as fp:
+      entry['hash'] = hashlib.sha1(fp.read()).hexdigest()
+
+    with tarfile.open(fullpath, 'r') as tar:
+      try:
+        json_member = tar.getmember(os.path.join(_get_parcel_dirname(f),
+                                    'meta', 'parcel.json'))
+      except KeyError:
+        print("Parcel does not contain parcel.json")
+        continue
+      try:
+        parcel = json.loads(tar.extractfile(json_member).read().decode(encoding='UTF-8'))
+      except:
+        print("Failed to parse parcel.json")
+        continue
+      _safe_copy('depends', parcel, entry)
+      _safe_copy('replaces', parcel, entry)
+      _safe_copy('conflicts', parcel, entry)
+      _safe_copy('components', parcel, entry)
+      _safe_copy('servicesRestartInfo', parcel, entry)
+
+      try:
+        notes_member = tar.getmember(os.path.join(_get_parcel_dirname(f),
+                                     'meta', 'release-notes.txt'))
+        entry['releaseNotes'] = tar.extractfile(notes_member).read().decode(encoding='UTF-8')
+      except KeyError:
+        # No problem if there's no release notes
+        pass
+
+    manifest['parcels'].append(entry)
+
+  return json.dumps(manifest, indent=4, separators=(',', ': '))
+
+if __name__ == "__main__":
+  path = os.path.curdir
+  if len(sys.argv) > 1:
+    path = sys.argv[1]
+  print("Scanning directory: %s" % (path))
+
+  manifest = make_manifest(path)
+  with open(os.path.join(path, 'manifest.json'), 'w') as fp:
+    fp.write(manifest)

--- a/phoenix-parcel/src/build/parcel.xml
+++ b/phoenix-parcel/src/build/parcel.xml
@@ -1,0 +1,40 @@
+<?xml version='1.0'?>
+<!--
+
+ Licensed to the Apache Software Foundation (ASF) under one
+ or more contributor license agreements.  See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership.  The ASF licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+
+-->
+
+<assembly xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.0 http://maven.apache.org/xsd/assembly-1.1.0.xsd">
+
+  <!--This 'all' id is not appended to the produced bundle because we do this: http://maven.apache.org/plugins/maven-assembly-plugin/faq.html#required-classifiers -->
+  <id>all</id>
+  <formats>
+    <format>tar</format>
+  </formats>
+  <includeBaseDirectory>false</includeBaseDirectory>
+
+  <componentDescriptors>
+    <componentDescriptor>src/build/components/all-common-files.xml</componentDescriptor>
+    <componentDescriptor>src/build/components/all-common-jars.xml</componentDescriptor>
+    <componentDescriptor>src/build/components/all-common-dependencies.xml</componentDescriptor>
+  </componentDescriptors>
+
+</assembly>

--- a/phoenix-parcel/src/parcel/bin/phoenix-performance.py
+++ b/phoenix-parcel/src/parcel/bin/phoenix-performance.py
@@ -1,0 +1,39 @@
+#!/bin/bash
+############################################################################
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+############################################################################
+
+  # Reference: http://stackoverflow.com/questions/59895/can-a-bash-script-tell-what-directory-its-stored-in
+  SOURCE="${BASH_SOURCE[0]}"
+  BIN_DIR="$( dirname "$SOURCE" )"
+  while [ -h "$SOURCE" ]
+  do
+    SOURCE="$(readlink "$SOURCE")"
+    [[ $SOURCE != /* ]] && SOURCE="$DIR/$SOURCE"
+    BIN_DIR="$( cd -P "$( dirname "$SOURCE" )" && pwd )"
+  done
+  BIN_DIR="$( cd -P "$( dirname "$SOURCE" )" && pwd )"
+  LIB_DIR=$BIN_DIR/../lib
+
+
+# Autodetect JAVA_HOME if not defined
+. $LIB_DIR/../../CDH/lib/bigtop-utils/bigtop-detect-javahome
+
+export PATH=$JAVA_HOME/jre/bin:$PATH
+exec $LIB_DIR/phoenix/bin/performance.py "$@"

--- a/phoenix-parcel/src/parcel/bin/phoenix-psql.py
+++ b/phoenix-parcel/src/parcel/bin/phoenix-psql.py
@@ -1,0 +1,39 @@
+#!/bin/bash
+############################################################################
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+############################################################################
+
+  # Reference: http://stackoverflow.com/questions/59895/can-a-bash-script-tell-what-directory-its-stored-in
+  SOURCE="${BASH_SOURCE[0]}"
+  BIN_DIR="$( dirname "$SOURCE" )"
+  while [ -h "$SOURCE" ]
+  do
+    SOURCE="$(readlink "$SOURCE")"
+    [[ $SOURCE != /* ]] && SOURCE="$DIR/$SOURCE"
+    BIN_DIR="$( cd -P "$( dirname "$SOURCE" )" && pwd )"
+  done
+  BIN_DIR="$( cd -P "$( dirname "$SOURCE" )" && pwd )"
+  LIB_DIR=$BIN_DIR/../lib
+
+
+# Autodetect JAVA_HOME if not defined
+. $LIB_DIR/../../CDH/lib/bigtop-utils/bigtop-detect-javahome
+
+export PATH=$JAVA_HOME/jre/bin:$PATH
+exec $LIB_DIR/phoenix/bin/psql.py "$@"

--- a/phoenix-parcel/src/parcel/bin/phoenix-sqlline.py
+++ b/phoenix-parcel/src/parcel/bin/phoenix-sqlline.py
@@ -1,0 +1,40 @@
+#!/bin/bash
+############################################################################
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+############################################################################
+
+  # Reference: http://stackoverflow.com/questions/59895/can-a-bash-script-tell-what-directory-its-stored-in
+  SOURCE="${BASH_SOURCE[0]}"
+  BIN_DIR="$( dirname "$SOURCE" )"
+  while [ -h "$SOURCE" ]
+  do
+    SOURCE="$(readlink "$SOURCE")"
+    [[ $SOURCE != /* ]] && SOURCE="$DIR/$SOURCE"
+    BIN_DIR="$( cd -P "$( dirname "$SOURCE" )" && pwd )"
+  done
+  BIN_DIR="$( cd -P "$( dirname "$SOURCE" )" && pwd )"
+  LIB_DIR=$BIN_DIR/../lib
+
+
+# Autodetect JAVA_HOME if not defined
+. $LIB_DIR/../../CDH/lib/bigtop-utils/bigtop-detect-javahome
+
+export HBASE_CONF_PATH=${HBASE_CONF_PATH:-/etc/hbase/conf}
+export PATH=$JAVA_HOME/jre/bin:$PATH
+exec $LIB_DIR/phoenix/bin/sqlline.py "$@"

--- a/phoenix-parcel/src/parcel/bin/phoenix-utils.py
+++ b/phoenix-parcel/src/parcel/bin/phoenix-utils.py
@@ -1,0 +1,39 @@
+#!/bin/bash
+############################################################################
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+############################################################################
+
+  # Reference: http://stackoverflow.com/questions/59895/can-a-bash-script-tell-what-directory-its-stored-in
+  SOURCE="${BASH_SOURCE[0]}"
+  BIN_DIR="$( dirname "$SOURCE" )"
+  while [ -h "$SOURCE" ]
+  do
+    SOURCE="$(readlink "$SOURCE")"
+    [[ $SOURCE != /* ]] && SOURCE="$DIR/$SOURCE"
+    BIN_DIR="$( cd -P "$( dirname "$SOURCE" )" && pwd )"
+  done
+  BIN_DIR="$( cd -P "$( dirname "$SOURCE" )" && pwd )"
+  LIB_DIR=$BIN_DIR/../lib
+
+
+# Autodetect JAVA_HOME if not defined
+. $LIB_DIR/../../CDH/lib/bigtop-utils/bigtop-detect-javahome
+
+export PATH=$JAVA_HOME/jre/bin:$PATH
+exec $LIB_DIR/phoenix/bin/phoenix_utils.py "$@"

--- a/phoenix-parcel/src/parcel/cloudera/cdh_version.properties
+++ b/phoenix-parcel/src/parcel/cloudera/cdh_version.properties
@@ -1,0 +1,19 @@
+############################################################################
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+############################################################################

--- a/phoenix-parcel/src/parcel/meta/alternatives.json
+++ b/phoenix-parcel/src/parcel/meta/alternatives.json
@@ -1,0 +1,26 @@
+{
+    "phoenix-performance.py": {
+      "destination": "/usr/bin/phoenix-performance.py",
+      "source": "bin/phoenix-performance.py",
+      "priority": 10,
+      "isDirectory": false
+    },
+    "phoenix-psql.py": {
+      "destination": "/usr/bin/phoenix-psql.py",
+      "source": "bin/phoenix-psql.py",
+      "priority": 10,
+      "isDirectory": false
+    },
+    "phoenix-sqlline.py": {
+      "destination": "/usr/bin/phoenix-sqlline.py",
+      "source": "bin/phoenix-sqlline.py",
+      "priority": 10,
+      "isDirectory": false
+    },
+    "phoenix-utils.py" : {
+      "destination": "/usr/bin/phoenix-utils.py",
+      "source": "bin/phoenix-utils.py",
+      "priority": 10,
+      "isDirectory": false
+    }
+}

--- a/phoenix-parcel/src/parcel/meta/parcel.json
+++ b/phoenix-parcel/src/parcel/meta/parcel.json
@@ -1,0 +1,34 @@
+{
+    "schema_version": 1,
+    "name": "APACHE_PHOENIX",
+    "version": "${parcel.version}",
+    "groups": [],
+    "extraVersionInfo": {
+        "baseVersion": "${parcel.base.version}",
+        "fullVersion": "${parcel.full.version}",
+        "patchCount": "${parcel.patch.count}"
+    },
+    "packages": [
+        {
+            "version": "${parcel.package.version}",
+            "name": "phoenix"
+        }
+    ],
+    "components": [
+        {
+            "name": "phoenix",
+            "version": "${parcel.component.version}",
+            "pkg_version": "${parcel.package.version}",
+            "pkg_release": "${parcel.component.release}"
+        }
+    ],
+    "scripts": {
+        "defines": "phoenix_env.sh"
+    },
+    "depends": "${parcel.depends}",
+    "provides": [
+        "hbase-plugin"
+    ],
+    "setActiveSymlink": true,
+    "users": {}
+}

--- a/phoenix-parcel/src/parcel/meta/phoenix_env.sh
+++ b/phoenix-parcel/src/parcel/meta/phoenix_env.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+############################################################################
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+############################################################################
+
+set -ex
+
+
+#The following is written to aid local testing
+if [ -z $PARCELS_ROOT ] ; then
+    export MYDIR=`dirname "${BASH_SOURCE[0]}"`
+    PARCELS_ROOT=`cd $MYDIR/../.. &&  pwd`
+fi
+PARCEL_DIRNAME=${PARCEL_DIRNAME-PHOENIX}
+
+MYLIBDIR=${PARCELS_ROOT}/${PARCEL_DIRNAME}/lib/phoenix
+
+[ -d $MYLIBDIR ] || {
+    echo "Could not find phoenix parcel lib dir, exiting" >&2
+    exit 1
+}
+
+APPENDSTRING=`echo ${MYLIBDIR}/*.jar | sed 's/ /:/g'`
+echo "appending '$APPENDSTRING' to HBASE_CLASSPATH"
+if [ -z $HBASE_CLASSPATH ] ; then
+    export HBASE_CLASSPATH=$APPENDSTRING
+else
+    export HBASE_CLASSPATH="$HBASE_CLASSPATH:$APPENDSTRING"
+fi
+echo "Set HBASE_CLASSPATH to '$HBASE_CLASSPATH'"
+echo "phoenix_env.sh successfully executed at `date`"

--- a/phoenix-pherf/pom.xml
+++ b/phoenix-pherf/pom.xml
@@ -15,7 +15,7 @@
 	<parent>
 		<groupId>org.apache.phoenix</groupId>
 		<artifactId>phoenix</artifactId>
-		<version>5.0.0-HBase-2.0</version>
+		<version>5.0.0-HBase-2.0-cdh6.0.1</version>
 	</parent>
 
 	<artifactId>phoenix-pherf</artifactId>

--- a/phoenix-pig/pom.xml
+++ b/phoenix-pig/pom.xml
@@ -26,7 +26,7 @@
   <parent>
     <groupId>org.apache.phoenix</groupId>
     <artifactId>phoenix</artifactId>
-    <version>5.0.0-HBase-2.0</version>
+    <version>5.0.0-HBase-2.0-cdh6.0.1</version>
   </parent>
   <artifactId>phoenix-pig</artifactId>
   <name>Phoenix - Pig</name>

--- a/phoenix-queryserver-client/pom.xml
+++ b/phoenix-queryserver-client/pom.xml
@@ -27,7 +27,7 @@
   <parent>
     <groupId>org.apache.phoenix</groupId>
     <artifactId>phoenix</artifactId>
-    <version>5.0.0-HBase-2.0</version>
+    <version>5.0.0-HBase-2.0-cdh6.0.1</version>
   </parent>
   <artifactId>phoenix-queryserver-client</artifactId>
   <name>Phoenix Query Server Client</name>

--- a/phoenix-queryserver/pom.xml
+++ b/phoenix-queryserver/pom.xml
@@ -26,7 +26,7 @@
   <parent>
     <groupId>org.apache.phoenix</groupId>
     <artifactId>phoenix</artifactId>
-    <version>5.0.0-HBase-2.0</version>
+    <version>5.0.0-HBase-2.0-cdh6.0.1</version>
   </parent>
   <artifactId>phoenix-queryserver</artifactId>
   <name>Phoenix Query Server</name>

--- a/phoenix-server/pom.xml
+++ b/phoenix-server/pom.xml
@@ -27,7 +27,7 @@
   <parent>
     <groupId>org.apache.phoenix</groupId>
     <artifactId>phoenix</artifactId>
-    <version>5.0.0-HBase-2.0</version>
+    <version>5.0.0-HBase-2.0-cdh6.0.1</version>
   </parent>
   <artifactId>phoenix-server</artifactId>
   <name>Phoenix Server</name>

--- a/phoenix-spark/pom.xml
+++ b/phoenix-spark/pom.xml
@@ -28,7 +28,7 @@
   <parent>
     <groupId>org.apache.phoenix</groupId>
     <artifactId>phoenix</artifactId>
-    <version>5.0.0-HBase-2.0</version>
+    <version>5.0.0-HBase-2.0-cdh6.0.1</version>
   </parent>
   <artifactId>phoenix-spark</artifactId>
   <name>Phoenix - Spark</name>

--- a/phoenix-tracing-webapp/pom.xml
+++ b/phoenix-tracing-webapp/pom.xml
@@ -27,7 +27,7 @@
     <parent>
       <groupId>org.apache.phoenix</groupId>
       <artifactId>phoenix</artifactId>
-      <version>5.0.0-HBase-2.0</version>
+      <version>5.0.0-HBase-2.0-cdh6.0.1</version>
     </parent>
 
     <artifactId>phoenix-tracing-webapp</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.apache.phoenix</groupId>
   <artifactId>phoenix</artifactId>
-  <version>5.0.0-HBase-2.0</version>
+  <version>5.0.0-HBase-2.0-cdh6.0.1</version>
   <packaging>pom</packaging>
   <name>Apache Phoenix</name>
   <description>A SQL layer over HBase</description>
@@ -44,6 +44,19 @@
       <id>apache release</id>
       <url>https://repository.apache.org/content/repositories/releases/</url>
     </repository>
+    <repository>
+      <id>cloudera</id>
+      <url>https://repository.cloudera.com/artifactory/cloudera-repos/</url>
+    </repository>
+    <repository>
+      <id>cdh.releases.repo</id>
+      <url>https://repository.cloudera.com/content/groups/cdh-releases-rcs</url>
+      <name>CDH Releases Repository</name>
+      <snapshots>
+        <enabled>false</enabled>
+      </snapshots>
+    </repository>
+
   </repositories>
 
   <parent>
@@ -65,33 +78,164 @@
     <test.output.tofile>true</test.output.tofile>
     <top.dir>${project.basedir}</top.dir>
 
+
+    <!--&lt;!&ndash;-->
+        <!--Versions of the projects we build/use-->
+    <!--&ndash;&gt;-->
+    <!--<cdh.parent.version>${project.version}</cdh.parent.version>-->
+    <!--<cdh.hadoop.version>3.0.0-cdh6.0.1</cdh.hadoop.version>-->
+    <!--<cdh.zookeeper.version>3.4.5-cdh6.0.1</cdh.zookeeper.version>-->
+    <!--<cdh.hbase.version>2.0.0-cdh6.0.1</cdh.hbase.version>-->
+    <!--<cdh.pig.version>0.17.0-cdh6.0.1</cdh.pig.version>-->
+    <!--<cdh.sqoop.version>1.4.7-cdh6.0.1</cdh.sqoop.version>-->
+    <!--<cdh.hive.version>2.1.1-cdh6.0.1</cdh.hive.version>-->
+    <!--<cdh.oozie.version>5.0.0-cdh6.0.1</cdh.oozie.version>-->
+    <!--<cdh.flume.version>0.9.4-cdh6.0.1</cdh.flume.version>-->
+    <!--<cdh.flume-ng.version>1.8.0-cdh6.0.1</cdh.flume-ng.version>-->
+    <!--<cdh.hue.version>3.9.0-cdh6.0.1</cdh.hue.version>-->
+    <!--<cdh.solr.version>7.0.0-cdh6.0.1</cdh.solr.version>-->
+    <!--<cdh.search.version>1.0.0-cdh6.0.1</cdh.search.version>-->
+    <!--<cdh.hbase-solr.version>1.5-cdh6.0.1</cdh.hbase-solr.version>-->
+    <!--<cdh.kite.version>1.0.0-cdh6.0.1</cdh.kite.version>-->
+    <!--<cdh.impala.version>3.0.0-cdh6.0.1</cdh.impala.version>-->
+    <!--<cdh.cdh-parcel.version>${project.version}</cdh.cdh-parcel.version>-->
+    <!--<cdh.sentry.version>2.0.0-cdh6.0.1</cdh.sentry.version>-->
+    <!--<cdh.apache-parquet.version>1.9.0-cdh6.0.1</cdh.apache-parquet.version>-->
+    <!--<cdh.apache-parquet-format.version>2.3.1-cdh6.0.1</cdh.apache-parquet-format.version>-->
+    <!--<cdh.spark.version>2.2.0-cdh6.0.1</cdh.spark.version>-->
+    <!--<cdh.spark-avro.version>3.2.1-cdh6.0.1</cdh.spark-avro.version>-->
+    <!--<cdh.crunch.version>0.11.0-cdh6.0.1</cdh.crunch.version>-->
+    <!--<cdh.avro.version>1.8.2-cdh6.0.1</cdh.avro.version>-->
+    <!--<cdh.kafka.version>1.0.1-cdh6.0.1</cdh.kafka.version>-->
+    <!--<cdh.kudu.version>1.6.0-cdh6.0.1</cdh.kudu.version>-->
+    <!--<cdh.hadoop-lzo.version>0.4.15-cdh6.0.1</cdh.hadoop-lzo.version>-->
+    <!--<cdh.impala-lzo.version>3.0.0-cdh6.0.1</cdh.impala-lzo.version>-->
+    <!--<cdh.spark-netlib.version>1.1-cdh6.0.1</cdh.spark-netlib.version>-->
+
+    <!--&lt;!&ndash;-->
+        <!--Versions of the third-party libraries we use-->
+      <!--&ndash;&gt;-->
+    <!--<cdh.activemq.version>5.15.2</cdh.activemq.version>-->
+    <!--<cdh.antcontrib>${cdh.antcontrib.version}</cdh.antcontrib>-->
+    <!--<cdh.antcontrib.version>1.0b3</cdh.antcontrib.version>-->
+    <!--<cdh.antlr.version>3.4</cdh.antlr.version>-->
+    <!--<cdh.aspectj.version>1.6.5</cdh.aspectj.version>-->
+    <!--<cdh.automaton.version>1.11-8</cdh.automaton.version>-->
+    <!--<cdh.checkstyle.version>4.2</cdh.checkstyle.version>-->
+    <!--<cdh.commons-beanutils.version>1.9.2</cdh.commons-beanutils.version>-->
+    <!--<cdh.commons-cli.version>1.4</cdh.commons-cli.version>-->
+    <!--<cdh.commons-codec.version>1.9</cdh.commons-codec.version>-->
+    <!--<cdh.commons-collections.version>3.2.2</cdh.commons-collections.version>-->
+    <!--<commons-collections.version>${cdh.commons-collections.version}</commons-collections.version>-->
+    <!--<cdh.commons-compress.version>1.4.1</cdh.commons-compress.version>-->
+    <!--<cdh.commons-configuration.version>1.6</cdh.commons-configuration.version>-->
+    <!--<cdh.commons-daemon.version>1.0.13</cdh.commons-daemon.version>-->
+    <!--<cdh.commons-dbcp.version>1.4</cdh.commons-dbcp.version>-->
+    <!--<cdh.commons-el.version>1.0</cdh.commons-el.version>-->
+    <!--<cdh.commons-el.version>1.0</cdh.commons-el.version>-->
+    <!--<cdh.commons.el.version>1.0</cdh.commons.el.version>-->
+    <!--<cdh.datanucleus-core.version>4.1.6</cdh.datanucleus-core.version>-->
+    <!--&lt;!&ndash; Obsolete: use cdh.httpcomponents.version &ndash;&gt;-->
+    <!--<cdh.commons-httpclient.version>3.1</cdh.commons-httpclient.version>-->
+    <!--<cdh.commons-io.version>2.6</cdh.commons-io.version>-->
+    <!--<cdh.commons-lang.version>2.6</cdh.commons-lang.version>-->
+    <!--<cdh.commons-lang3.version>3.7</cdh.commons-lang3.version>-->
+    <!--<commons-lang.version>${cdh.commons-lang.version}</commons-lang.version>-->
+    <!--<cdh.commons-logging.version>1.1.3</cdh.commons-logging.version>-->
+    <!--<cdh.commons-math.version>2.1</cdh.commons-math.version>-->
+    <!--<cdh.commons-math.version>2.1</cdh.commons-math.version>-->
+    <!--<cdh.commons-net.version>3.1</cdh.commons-net.version>-->
+    <!--<cdh.curator.version>2.7.1</cdh.curator.version>-->
+    <!--&lt;!&ndash; OWASP's dependency-check &ndash;&gt;-->
+    <!--<cdh.dependency-check-maven.version>1.4.3</cdh.dependency-check-maven.version>-->
+    <!--<cdh.derby.version>10.14.1.0</cdh.derby.version>-->
+    <!--<cdh.eclipse-jetty.version>7.6.0.v20120127</cdh.eclipse-jetty.version>-->
+    <!--<cdh.fastutil.version>7.2.1</cdh.fastutil.version>-->
+    <!--<cdh.findbugs.version>3.0.0</cdh.findbugs.version>-->
+    <!--<cdh.guava.version>11.0.2</cdh.guava.version>-->
+    <!--<cdh.hadoop-snappy.version>1.1.4</cdh.hadoop-snappy.version>-->
+    <!--<cdh.hsqldb.version>1.8.0.10</cdh.hsqldb.version>-->
+    <!--<cdh.htrace.version>4.1.0-incubating</cdh.htrace.version>-->
+    <!--&lt;!&ndash; The httpcomponents-client version (the first below) is not necessarily-->
+         <!--the same as the httpcomponents core version. &ndash;&gt;-->
+    <!--<cdh.httpcomponents.version>4.5.3</cdh.httpcomponents.version>-->
+    <!--<cdh.httpcomponents.core.version>4.4.6</cdh.httpcomponents.core.version>-->
+    <!--<cdh.io.netty-all.version>4.1.17.Final</cdh.io.netty-all.version>-->
+    <!--<cdh.io.netty.version>3.10.5.Final</cdh.io.netty.version>-->
+    <!--<cdh.jackson2.version>2.9.5</cdh.jackson2.version>-->
+    <!--<cdh.jackson.version>1.9.13</cdh.jackson.version>-->
+    <!--<cdh.jackson-mapper-asl.version>1.9.13-cloudera.1</cdh.jackson-mapper-asl.version>-->
+    <!--<cdh.jansi.version>1.9</cdh.jansi.version>-->
+    <!--<cdh.jasper.version>5.5.23</cdh.jasper.version>-->
+    <!--<cdh.javacc.version>4.2</cdh.javacc.version>-->
+    <!--<cdh.jaxb-api.version>2.2.11</cdh.jaxb-api.version>-->
+    <!--<cdh.jdiff.version>1.0.9</cdh.jdiff.version>-->
+    <!--<cdh.jersey.version>1.19</cdh.jersey.version>-->
+    <!--<cdh.jets3t.version>0.9.0</cdh.jets3t.version>-->
+    <!--<cdh.jetty-jsp.version>6.1.14</cdh.jetty-jsp.version>-->
+    <!--<cdh.jetty.version>6.1.26.cloudera.4</cdh.jetty.version>-->
+    <!--<cdh.jetty9.version>9.3.20.v20170531</cdh.jetty9.version>-->
+    <!--<cdh.jline.version>2.12</cdh.jline.version>-->
+    <!--<cdh.jmh.version>1.19</cdh.jmh.version>-->
+    <!--<cdh.jms.version>1.1</cdh.jms.version>-->
+    <!--<cdh.joda-time.version>2.9.9</cdh.joda-time.version>-->
+    <!--<cdh.joda.version>${cdh.joda-time.version}</cdh.joda.version>-->
+    <!--<cdh.jsch.version>0.1.42</cdh.jsch.version>-->
+    <!--<cdh.json-simple.version>1.1</cdh.json-simple.version>-->
+    <!--<cdh.jsp-api.version>2.1</cdh.jsp-api.version>-->
+    <!--<cdh.junit.version>4.8.1</cdh.junit.version>-->
+    <!--<cdh.jython.version>2.5.2</cdh.jython.version>-->
+    <!--<cdh.kerby.version>1.0.0</cdh.kerby.version>-->
+    <!--<cdh.kfs.version>0.3</cdh.kfs.version>-->
+    <!--<cdh.log4j.version>1.2.17</cdh.log4j.version>-->
+    <!--&lt;!&ndash; The logredactor implementation is currently only needed at-->
+         <!--runtime, but managed as a third party lib proactively for when-->
+         <!--it gets used directly by components in the future.  &ndash;&gt;-->
+    <!--<cdh.logredactor.version>2.0.6</cdh.logredactor.version>-->
+    <!--<cdh.metrics-core.version>3.0.2</cdh.metrics-core.version>-->
+    <!--<cdh.mina.version>2.0.0-M5</cdh.mina.version>-->
+    <!--<cdh.mockito.version>1.9.5</cdh.mockito.version>-->
+    <!--<cdh.oro.version>2.0.8</cdh.oro.version>-->
+    <!--<cdh.rat.version>0.6</cdh.rat.version>-->
+    <!--<cdh.servlet-api.version>2.5</cdh.servlet-api.version>-->
+    <!--<cdh.slf4j.version>1.7.25</cdh.slf4j.version>-->
+    <!--<cdh.surefire.version>2.20</cdh.surefire.version>-->
+    <!--<cdh.testng.version>6.2</cdh.testng.version>-->
+    <!--<cdh.testng.version>6.2</cdh.testng.version>-->
+    <!--<cdh.thrift.version>0.9.3</cdh.thrift.version>-->
+    <!--<cdh.tika.version>1.16</cdh.tika.version>-->
+    <!--&lt;!&ndash; Dependency version reporting &ndash;&gt;-->
+    <!--<cdh.versions-maven-plugin.version>2.3</cdh.versions-maven-plugin.version>-->
+    <!--<cdh.xerces.version>1.4.4</cdh.xerces.version>-->
+    <!--<cdh.xmlenc.version>0.52</cdh.xmlenc.version>-->
+
     <!-- Hadoop Versions -->
-    <hbase.version>2.0.0</hbase.version>
-    <hadoop.version>3.0.0</hadoop.version>
+    <hbase.version>2.0.0-cdh6.0.1</hbase.version>
+    <hadoop.version>3.0.0-cdh6.0.1</hadoop.version>
 
     <!-- Dependency versions -->
     <commons-cli.version>1.4</commons-cli.version>
-    <hive.version>3.0.0</hive.version>
-    <pig.version>0.13.0</pig.version>
-    <jackson.version>1.9.2</jackson.version>
+    <hive.version>2.1.1-cdh6.0.1</hive.version>
+    <pig.version>0.17.0-cdh6.0.1</pig.version>
+    <jackson.version>1.9.13</jackson.version>
     <antlr.version>3.5.2</antlr.version>
     <log4j.version>1.2.17</log4j.version>
     <disruptor.version>3.3.6</disruptor.version>
-    <slf4j.version>1.6.4</slf4j.version>
+    <slf4j.version>1.7.25</slf4j.version>
     <protobuf-java.version>2.5.0</protobuf-java.version>
-    <commons-io.version>2.1</commons-io.version>
-    <commons-lang.version>2.5</commons-lang.version>
+    <commons-io.version>2.6</commons-io.version>
+    <commons-lang.version>2.6</commons-lang.version>
     <commons-logging.version>1.2</commons-logging.version>
     <commons-csv.version>1.0</commons-csv.version>
     <sqlline.version>1.2.0</sqlline.version>
     <guava.version>13.0.1</guava.version>
-    <flume.version>1.4.0</flume.version>
-    <kafka.version>0.9.0.0</kafka.version>
+    <flume.version>1.8.0-cdh6.0.1</flume.version>
+    <kafka.version>1.0.1-cdh6.0.1</kafka.version>
     <findbugs-annotations.version>1.3.9-1</findbugs-annotations.version>
     <jcip-annotations.version>1.0-1</jcip-annotations.version>
     <jline.version>2.11</jline.version>
     <snappy.version>0.3</snappy.version>
-    <commons-codec.version>1.7</commons-codec.version>
+    <commons-codec.version>1.9</commons-codec.version>
     <htrace.version>3.1.0-incubating</htrace.version>
     <collections.version>3.2.2</collections.version>
     <!-- Do not change jodatime.version until HBASE-15199 is fixed -->
@@ -100,7 +244,7 @@
     <avatica.version>1.11.0</avatica.version>
     <jetty.version>9.3.19.v20170502</jetty.version>
     <tephra.version>0.14.0-incubating</tephra.version>
-    <spark.version>2.3.0</spark.version>
+    <spark.version>2.2.0-cdh6.0.1</spark.version>
     <scala.version>2.11.8</scala.version>
     <scala.binary.version>2.11</scala.binary.version>
     <stream.version>2.9.5</stream.version>
@@ -548,6 +692,13 @@
       </dependency>
 
       <!-- HBase dependencies -->
+      <!-- Failed to read artifact descriptor for org.glassfish:javax.el:jar:3.0.1-b06-SNAPSHOT -->
+      <!--<dependency>-->
+        <!--<groupId>org.glassfish</groupId>-->
+        <!--<artifactId>javax.el</artifactId>-->
+        <!--<version>3.0.1-b10</version>-->
+        <!--<scope>provided</scope>-->
+      <!--</dependency>-->
       <dependency>
         <groupId>org.apache.hbase</groupId>
         <artifactId>hbase-annotations</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -78,145 +78,16 @@
     <test.output.tofile>true</test.output.tofile>
     <top.dir>${project.basedir}</top.dir>
 
-
-    <!--&lt;!&ndash;-->
-        <!--Versions of the projects we build/use-->
-    <!--&ndash;&gt;-->
-    <!--<cdh.parent.version>${project.version}</cdh.parent.version>-->
-    <!--<cdh.hadoop.version>3.0.0-cdh6.0.1</cdh.hadoop.version>-->
-    <!--<cdh.zookeeper.version>3.4.5-cdh6.0.1</cdh.zookeeper.version>-->
-    <!--<cdh.hbase.version>2.0.0-cdh6.0.1</cdh.hbase.version>-->
-    <!--<cdh.pig.version>0.17.0-cdh6.0.1</cdh.pig.version>-->
-    <!--<cdh.sqoop.version>1.4.7-cdh6.0.1</cdh.sqoop.version>-->
-    <!--<cdh.hive.version>2.1.1-cdh6.0.1</cdh.hive.version>-->
-    <!--<cdh.oozie.version>5.0.0-cdh6.0.1</cdh.oozie.version>-->
-    <!--<cdh.flume.version>0.9.4-cdh6.0.1</cdh.flume.version>-->
-    <!--<cdh.flume-ng.version>1.8.0-cdh6.0.1</cdh.flume-ng.version>-->
-    <!--<cdh.hue.version>3.9.0-cdh6.0.1</cdh.hue.version>-->
-    <!--<cdh.solr.version>7.0.0-cdh6.0.1</cdh.solr.version>-->
-    <!--<cdh.search.version>1.0.0-cdh6.0.1</cdh.search.version>-->
-    <!--<cdh.hbase-solr.version>1.5-cdh6.0.1</cdh.hbase-solr.version>-->
-    <!--<cdh.kite.version>1.0.0-cdh6.0.1</cdh.kite.version>-->
-    <!--<cdh.impala.version>3.0.0-cdh6.0.1</cdh.impala.version>-->
-    <!--<cdh.cdh-parcel.version>${project.version}</cdh.cdh-parcel.version>-->
-    <!--<cdh.sentry.version>2.0.0-cdh6.0.1</cdh.sentry.version>-->
-    <!--<cdh.apache-parquet.version>1.9.0-cdh6.0.1</cdh.apache-parquet.version>-->
-    <!--<cdh.apache-parquet-format.version>2.3.1-cdh6.0.1</cdh.apache-parquet-format.version>-->
-    <!--<cdh.spark.version>2.2.0-cdh6.0.1</cdh.spark.version>-->
-    <!--<cdh.spark-avro.version>3.2.1-cdh6.0.1</cdh.spark-avro.version>-->
-    <!--<cdh.crunch.version>0.11.0-cdh6.0.1</cdh.crunch.version>-->
-    <!--<cdh.avro.version>1.8.2-cdh6.0.1</cdh.avro.version>-->
-    <!--<cdh.kafka.version>1.0.1-cdh6.0.1</cdh.kafka.version>-->
-    <!--<cdh.kudu.version>1.6.0-cdh6.0.1</cdh.kudu.version>-->
-    <!--<cdh.hadoop-lzo.version>0.4.15-cdh6.0.1</cdh.hadoop-lzo.version>-->
-    <!--<cdh.impala-lzo.version>3.0.0-cdh6.0.1</cdh.impala-lzo.version>-->
-    <!--<cdh.spark-netlib.version>1.1-cdh6.0.1</cdh.spark-netlib.version>-->
-
-    <!--&lt;!&ndash;-->
-        <!--Versions of the third-party libraries we use-->
-      <!--&ndash;&gt;-->
-    <!--<cdh.activemq.version>5.15.2</cdh.activemq.version>-->
-    <!--<cdh.antcontrib>${cdh.antcontrib.version}</cdh.antcontrib>-->
-    <!--<cdh.antcontrib.version>1.0b3</cdh.antcontrib.version>-->
-    <!--<cdh.antlr.version>3.4</cdh.antlr.version>-->
-    <!--<cdh.aspectj.version>1.6.5</cdh.aspectj.version>-->
-    <!--<cdh.automaton.version>1.11-8</cdh.automaton.version>-->
-    <!--<cdh.checkstyle.version>4.2</cdh.checkstyle.version>-->
-    <!--<cdh.commons-beanutils.version>1.9.2</cdh.commons-beanutils.version>-->
-    <!--<cdh.commons-cli.version>1.4</cdh.commons-cli.version>-->
-    <!--<cdh.commons-codec.version>1.9</cdh.commons-codec.version>-->
-    <!--<cdh.commons-collections.version>3.2.2</cdh.commons-collections.version>-->
-    <!--<commons-collections.version>${cdh.commons-collections.version}</commons-collections.version>-->
-    <!--<cdh.commons-compress.version>1.4.1</cdh.commons-compress.version>-->
-    <!--<cdh.commons-configuration.version>1.6</cdh.commons-configuration.version>-->
-    <!--<cdh.commons-daemon.version>1.0.13</cdh.commons-daemon.version>-->
-    <!--<cdh.commons-dbcp.version>1.4</cdh.commons-dbcp.version>-->
-    <!--<cdh.commons-el.version>1.0</cdh.commons-el.version>-->
-    <!--<cdh.commons-el.version>1.0</cdh.commons-el.version>-->
-    <!--<cdh.commons.el.version>1.0</cdh.commons.el.version>-->
-    <!--<cdh.datanucleus-core.version>4.1.6</cdh.datanucleus-core.version>-->
-    <!--&lt;!&ndash; Obsolete: use cdh.httpcomponents.version &ndash;&gt;-->
-    <!--<cdh.commons-httpclient.version>3.1</cdh.commons-httpclient.version>-->
-    <!--<cdh.commons-io.version>2.6</cdh.commons-io.version>-->
-    <!--<cdh.commons-lang.version>2.6</cdh.commons-lang.version>-->
-    <!--<cdh.commons-lang3.version>3.7</cdh.commons-lang3.version>-->
-    <!--<commons-lang.version>${cdh.commons-lang.version}</commons-lang.version>-->
-    <!--<cdh.commons-logging.version>1.1.3</cdh.commons-logging.version>-->
-    <!--<cdh.commons-math.version>2.1</cdh.commons-math.version>-->
-    <!--<cdh.commons-math.version>2.1</cdh.commons-math.version>-->
-    <!--<cdh.commons-net.version>3.1</cdh.commons-net.version>-->
-    <!--<cdh.curator.version>2.7.1</cdh.curator.version>-->
-    <!--&lt;!&ndash; OWASP's dependency-check &ndash;&gt;-->
-    <!--<cdh.dependency-check-maven.version>1.4.3</cdh.dependency-check-maven.version>-->
-    <!--<cdh.derby.version>10.14.1.0</cdh.derby.version>-->
-    <!--<cdh.eclipse-jetty.version>7.6.0.v20120127</cdh.eclipse-jetty.version>-->
-    <!--<cdh.fastutil.version>7.2.1</cdh.fastutil.version>-->
-    <!--<cdh.findbugs.version>3.0.0</cdh.findbugs.version>-->
-    <!--<cdh.guava.version>11.0.2</cdh.guava.version>-->
-    <!--<cdh.hadoop-snappy.version>1.1.4</cdh.hadoop-snappy.version>-->
-    <!--<cdh.hsqldb.version>1.8.0.10</cdh.hsqldb.version>-->
-    <!--<cdh.htrace.version>4.1.0-incubating</cdh.htrace.version>-->
-    <!--&lt;!&ndash; The httpcomponents-client version (the first below) is not necessarily-->
-         <!--the same as the httpcomponents core version. &ndash;&gt;-->
-    <!--<cdh.httpcomponents.version>4.5.3</cdh.httpcomponents.version>-->
-    <!--<cdh.httpcomponents.core.version>4.4.6</cdh.httpcomponents.core.version>-->
-    <!--<cdh.io.netty-all.version>4.1.17.Final</cdh.io.netty-all.version>-->
-    <!--<cdh.io.netty.version>3.10.5.Final</cdh.io.netty.version>-->
-    <!--<cdh.jackson2.version>2.9.5</cdh.jackson2.version>-->
-    <!--<cdh.jackson.version>1.9.13</cdh.jackson.version>-->
-    <!--<cdh.jackson-mapper-asl.version>1.9.13-cloudera.1</cdh.jackson-mapper-asl.version>-->
-    <!--<cdh.jansi.version>1.9</cdh.jansi.version>-->
-    <!--<cdh.jasper.version>5.5.23</cdh.jasper.version>-->
-    <!--<cdh.javacc.version>4.2</cdh.javacc.version>-->
-    <!--<cdh.jaxb-api.version>2.2.11</cdh.jaxb-api.version>-->
-    <!--<cdh.jdiff.version>1.0.9</cdh.jdiff.version>-->
-    <!--<cdh.jersey.version>1.19</cdh.jersey.version>-->
-    <!--<cdh.jets3t.version>0.9.0</cdh.jets3t.version>-->
-    <!--<cdh.jetty-jsp.version>6.1.14</cdh.jetty-jsp.version>-->
-    <!--<cdh.jetty.version>6.1.26.cloudera.4</cdh.jetty.version>-->
-    <!--<cdh.jetty9.version>9.3.20.v20170531</cdh.jetty9.version>-->
-    <!--<cdh.jline.version>2.12</cdh.jline.version>-->
-    <!--<cdh.jmh.version>1.19</cdh.jmh.version>-->
-    <!--<cdh.jms.version>1.1</cdh.jms.version>-->
-    <!--<cdh.joda-time.version>2.9.9</cdh.joda-time.version>-->
-    <!--<cdh.joda.version>${cdh.joda-time.version}</cdh.joda.version>-->
-    <!--<cdh.jsch.version>0.1.42</cdh.jsch.version>-->
-    <!--<cdh.json-simple.version>1.1</cdh.json-simple.version>-->
-    <!--<cdh.jsp-api.version>2.1</cdh.jsp-api.version>-->
-    <!--<cdh.junit.version>4.8.1</cdh.junit.version>-->
-    <!--<cdh.jython.version>2.5.2</cdh.jython.version>-->
-    <!--<cdh.kerby.version>1.0.0</cdh.kerby.version>-->
-    <!--<cdh.kfs.version>0.3</cdh.kfs.version>-->
-    <!--<cdh.log4j.version>1.2.17</cdh.log4j.version>-->
-    <!--&lt;!&ndash; The logredactor implementation is currently only needed at-->
-         <!--runtime, but managed as a third party lib proactively for when-->
-         <!--it gets used directly by components in the future.  &ndash;&gt;-->
-    <!--<cdh.logredactor.version>2.0.6</cdh.logredactor.version>-->
-    <!--<cdh.metrics-core.version>3.0.2</cdh.metrics-core.version>-->
-    <!--<cdh.mina.version>2.0.0-M5</cdh.mina.version>-->
-    <!--<cdh.mockito.version>1.9.5</cdh.mockito.version>-->
-    <!--<cdh.oro.version>2.0.8</cdh.oro.version>-->
-    <!--<cdh.rat.version>0.6</cdh.rat.version>-->
-    <!--<cdh.servlet-api.version>2.5</cdh.servlet-api.version>-->
-    <!--<cdh.slf4j.version>1.7.25</cdh.slf4j.version>-->
-    <!--<cdh.surefire.version>2.20</cdh.surefire.version>-->
-    <!--<cdh.testng.version>6.2</cdh.testng.version>-->
-    <!--<cdh.testng.version>6.2</cdh.testng.version>-->
-    <!--<cdh.thrift.version>0.9.3</cdh.thrift.version>-->
-    <!--<cdh.tika.version>1.16</cdh.tika.version>-->
-    <!--&lt;!&ndash; Dependency version reporting &ndash;&gt;-->
-    <!--<cdh.versions-maven-plugin.version>2.3</cdh.versions-maven-plugin.version>-->
-    <!--<cdh.xerces.version>1.4.4</cdh.xerces.version>-->
-    <!--<cdh.xmlenc.version>0.52</cdh.xmlenc.version>-->
-
     <!-- Hadoop Versions -->
     <hbase.version>2.0.0-cdh6.0.1</hbase.version>
     <hadoop.version>3.0.0-cdh6.0.1</hadoop.version>
 
     <!-- Dependency versions -->
     <commons-cli.version>1.4</commons-cli.version>
-    <hive.version>2.1.1-cdh6.0.1</hive.version>
-    <pig.version>0.17.0-cdh6.0.1</pig.version>
+    <!--BROKEN <hive.version>2.1.1-cdh6.0.1</hive.version>-->
+    <hive.version>3.0.0</hive.version>
+    <!--BROKEN <pig.version>0.17.0-cdh6.0.1</pig.version>-->
+    <pig.version>0.13.0</pig.version>
     <jackson.version>1.9.13</jackson.version>
     <antlr.version>3.5.2</antlr.version>
     <log4j.version>1.2.17</log4j.version>
@@ -230,7 +101,8 @@
     <sqlline.version>1.2.0</sqlline.version>
     <guava.version>13.0.1</guava.version>
     <flume.version>1.8.0-cdh6.0.1</flume.version>
-    <kafka.version>1.0.1-cdh6.0.1</kafka.version>
+    <!--BROKEN <kafka.version>1.0.1-cdh6.0.1</kafka.version>-->
+    <kafka.version>0.9.0.0</kafka.version>
     <findbugs-annotations.version>1.3.9-1</findbugs-annotations.version>
     <jcip-annotations.version>1.0-1</jcip-annotations.version>
     <jline.version>2.11</jline.version>

--- a/pom.xml
+++ b/pom.xml
@@ -79,6 +79,7 @@
     <test.output.tofile>true</test.output.tofile>
     <top.dir>${project.basedir}</top.dir>
 
+    <cdh.version>6.0.1</cdh.version>
     <!-- Hadoop Versions -->
     <hbase.version>2.0.0-cdh6.0.1</hbase.version>
     <hadoop.version>3.0.0-cdh6.0.1</hadoop.version>

--- a/pom.xml
+++ b/pom.xml
@@ -464,6 +464,24 @@
                  <goal>verify</goal>
               </goals>
             </execution>
+<execution>
+              <id>SplitSystemCatalogTests</id>
+              <configuration>
+                 <encoding>UTF-8</encoding>
+                 <forkCount>${numForkedIT}</forkCount>
+                 <runOrder>alphabetical</runOrder>
+                 <reuseForks>false</reuseForks>
+                 <argLine>-enableassertions -Xmx2000m -XX:MaxPermSize=256m -Djava.security.egd=file:/dev/./urandom "-Djava.library.path=${hadoop.library.path}${path.separator}${java.library.path}" -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=./target/</argLine>
+                 <redirectTestOutputToFile>${test.output.tofile}</redirectTestOutputToFile>
+                 <testSourceDirectory>${basedir}/src/it/java</testSourceDirectory>
+                 <groups>org.apache.phoenix.end2end.SplitSystemCatalogTests</groups>
+                 <shutdown>kill</shutdown>
+              </configuration>
+              <goals>
+                 <goal>integration-test</goal>
+                 <goal>verify</goal>
+              </goals>
+            </execution>
           </executions>
         </plugin>
         <plugin>


### PR DESCRIPTION
New 5.0.0-HBase-2.0-cdh6.0.1 branch created from: 

https://github.com/apache/phoenix/commits/v5.0.0-HBase-2.0

This PR is for minimum additional changes to get this branch working and includes:

- Milan's parcel additions
- dependency updates to match CDH 6.0.1 platform (a couple reverted as broken but we don't need)
- support for HBase 2.0 (to get it to build)

If we decide more fixes are needed, we can look here to find them:

https://github.com/hortonworks/phoenix-release/commits/8c1451004f2077a004f4624a761da28fcdcccbea

as HWX has pulled in a few changes (probably for good reasons).