### PR TITLE
4.14-HBase-1.4_cloud_custom

### DIFF
--- a/phoenix-assembly/pom.xml
+++ b/phoenix-assembly/pom.xml
@@ -27,7 +27,7 @@
   <parent>
     <groupId>org.apache.phoenix</groupId>
     <artifactId>phoenix</artifactId>
-    <version>4.14.1-HBase-1.4</version>
+    <version>4.14.1-HBase-1.4_cloud_custom</version>
   </parent>
   <artifactId>phoenix-assembly</artifactId>
   <name>Phoenix Assembly</name>

--- a/phoenix-client/pom.xml
+++ b/phoenix-client/pom.xml
@@ -27,7 +27,7 @@
   <parent>
     <groupId>org.apache.phoenix</groupId>
     <artifactId>phoenix</artifactId>
-    <version>4.14.1-HBase-1.4</version>
+    <version>4.14.1-HBase-1.4_cloud_custom</version>
   </parent>
   <artifactId>phoenix-client</artifactId>
   <name>Phoenix Client</name>

--- a/phoenix-core/pom.xml
+++ b/phoenix-core/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.apache.phoenix</groupId>
     <artifactId>phoenix</artifactId>
-    <version>4.14.1-HBase-1.4</version>
+    <version>4.14.1-HBase-1.4_cloud_custom</version>
   </parent>
   <artifactId>phoenix-core</artifactId>
   <name>Phoenix Core</name>

--- a/phoenix-flume/pom.xml
+++ b/phoenix-flume/pom.xml
@@ -26,7 +26,7 @@
   <parent>
     <groupId>org.apache.phoenix</groupId>
     <artifactId>phoenix</artifactId>
-    <version>4.14.1-HBase-1.4</version>
+    <version>4.14.1-HBase-1.4_cloud_custom</version>
   </parent>
   <artifactId>phoenix-flume</artifactId>
   <name>Phoenix - Flume</name>

--- a/phoenix-hive/pom.xml
+++ b/phoenix-hive/pom.xml
@@ -27,7 +27,7 @@
   <parent>
     <groupId>org.apache.phoenix</groupId>
     <artifactId>phoenix</artifactId>
-    <version>4.14.1-HBase-1.4</version>
+    <version>4.14.1-HBase-1.4_cloud_custom</version>
   </parent>
   <artifactId>phoenix-hive</artifactId>
   <name>Phoenix - Hive</name>

--- a/phoenix-kafka/pom.xml
+++ b/phoenix-kafka/pom.xml
@@ -26,7 +26,7 @@
 	<parent>
 		<groupId>org.apache.phoenix</groupId>
 		<artifactId>phoenix</artifactId>
-		<version>4.14.1-HBase-1.4</version>
+		<version>4.14.1-HBase-1.4_cloud_custom</version>
 	</parent>
 	<artifactId>phoenix-kafka</artifactId>
 	<name>Phoenix - Kafka</name>

--- a/phoenix-load-balancer/pom.xml
+++ b/phoenix-load-balancer/pom.xml
@@ -27,7 +27,7 @@
   <parent>
     <groupId>org.apache.phoenix</groupId>
     <artifactId>phoenix</artifactId>
-    <version>4.14.1-HBase-1.4</version>
+    <version>4.14.1-HBase-1.4_cloud_custom</version>
   </parent>
   <artifactId>phoenix-load-balancer</artifactId>
   <name>Phoenix Load Balancer</name>

--- a/phoenix-pherf/pom.xml
+++ b/phoenix-pherf/pom.xml
@@ -15,7 +15,7 @@
 	<parent>
 		<groupId>org.apache.phoenix</groupId>
 		<artifactId>phoenix</artifactId>
-		<version>4.14.1-HBase-1.4</version>
+		<version>4.14.1-HBase-1.4_cloud_custom</version>
 	</parent>
 
 	<artifactId>phoenix-pherf</artifactId>

--- a/phoenix-pig/pom.xml
+++ b/phoenix-pig/pom.xml
@@ -26,7 +26,7 @@
   <parent>
     <groupId>org.apache.phoenix</groupId>
     <artifactId>phoenix</artifactId>
-    <version>4.14.1-HBase-1.4</version>
+    <version>4.14.1-HBase-1.4_cloud_custom</version>
   </parent>
   <artifactId>phoenix-pig</artifactId>
   <name>Phoenix - Pig</name>

--- a/phoenix-queryserver-client/pom.xml
+++ b/phoenix-queryserver-client/pom.xml
@@ -27,7 +27,7 @@
   <parent>
     <groupId>org.apache.phoenix</groupId>
     <artifactId>phoenix</artifactId>
-    <version>4.14.1-HBase-1.4</version>
+    <version>4.14.1-HBase-1.4_cloud_custom</version>
   </parent>
   <artifactId>phoenix-queryserver-client</artifactId>
   <name>Phoenix Query Server Client</name>

--- a/phoenix-queryserver/pom.xml
+++ b/phoenix-queryserver/pom.xml
@@ -26,7 +26,7 @@
   <parent>
     <groupId>org.apache.phoenix</groupId>
     <artifactId>phoenix</artifactId>
-    <version>4.14.1-HBase-1.4</version>
+    <version>4.14.1-HBase-1.4_cloud_custom</version>
   </parent>
   <artifactId>phoenix-queryserver</artifactId>
   <name>Phoenix Query Server</name>

--- a/phoenix-server/pom.xml
+++ b/phoenix-server/pom.xml
@@ -27,7 +27,7 @@
   <parent>
     <groupId>org.apache.phoenix</groupId>
     <artifactId>phoenix</artifactId>
-    <version>4.14.1-HBase-1.4</version>
+    <version>4.14.1-HBase-1.4_cloud_custom</version>
   </parent>
   <artifactId>phoenix-server</artifactId>
   <name>Phoenix Server</name>

--- a/phoenix-spark/pom.xml
+++ b/phoenix-spark/pom.xml
@@ -28,7 +28,7 @@
   <parent>
     <groupId>org.apache.phoenix</groupId>
     <artifactId>phoenix</artifactId>
-    <version>4.14.1-HBase-1.4</version>
+    <version>4.14.1-HBase-1.4_cloud_custom</version>
   </parent>
   <artifactId>phoenix-spark</artifactId>
   <name>Phoenix - Spark</name>

--- a/phoenix-spark/src/main/scala/org/apache/phoenix/spark/PhoenixRelation.scala
+++ b/phoenix-spark/src/main/scala/org/apache/phoenix/spark/PhoenixRelation.scala
@@ -84,9 +84,9 @@ case class PhoenixRelation(tableName: String, zkUrl: String, dateAsTimestamp: Bo
 
       f match {
         // Spark 1.3.1+ supported filters
-        case And(leftFilter, rightFilter) => filter.append(buildFilter(Array(leftFilter, rightFilter)))
-        case Or(leftFilter, rightFilter) => filter.append(buildFilter(Array(leftFilter)) + " OR " + buildFilter(Array(rightFilter)))
-        case Not(aFilter) => filter.append(" NOT " + buildFilter(Array(aFilter)))
+        case And(leftFilter, rightFilter) => filter.append("(" + buildFilter(Array(leftFilter, rightFilter)) + ")")
+        case Or(leftFilter, rightFilter) => filter.append("(" + buildFilter(Array(leftFilter)) + " OR " + buildFilter(Array(rightFilter)) + ")")
+        case Not(aFilter) => filter.append(" NOT " + "(" + buildFilter(Array(aFilter)) + ")")
         case EqualTo(attr, value) => filter.append(s" ${escapeKey(attr)} = ${compileValue(value)}")
         case GreaterThan(attr, value) => filter.append(s" ${escapeKey(attr)} > ${compileValue(value)}")
         case GreaterThanOrEqual(attr, value) => filter.append(s" ${escapeKey(attr)} >= ${compileValue(value)}")

--- a/phoenix-tracing-webapp/pom.xml
+++ b/phoenix-tracing-webapp/pom.xml
@@ -27,7 +27,7 @@
     <parent>
       <groupId>org.apache.phoenix</groupId>
       <artifactId>phoenix</artifactId>
-      <version>4.14.1-HBase-1.4</version>
+      <version>4.14.1-HBase-1.4_cloud_custom</version>
     </parent>
 
     <artifactId>phoenix-tracing-webapp</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.apache.phoenix</groupId>
   <artifactId>phoenix</artifactId>
-  <version>4.14.1-HBase-1.4</version>
+  <version>4.14.1-HBase-1.4_cloud_custom</version>
   <packaging>pom</packaging>
   <name>Apache Phoenix</name>
   <description>A SQL layer over HBase</description>


### PR DESCRIPTION
Custom branch 4.14-HBase-1.4_custom created from:

[4.14-HBase-1.4](https://github.com/FileTrek/phoenix/tree/4.14-HBase-1.4)

emr-releases-5.23.x uses the pheonix version 4.14.1, Hbase version 1.4.9


![Screen Shot 2019-08-07 at 11 27 36 AM](https://user-images.githubusercontent.com/50878546/62636814-4204d280-b908-11e9-80a8-a5fd85cf7dc5.png)

[official release documentation](https://docs.aws.amazon.com/emr/latest/ReleaseGuide/emr-release-5x.html)

This PR includes changes to the Phoenix timestamp pushdown filter fix for the EMR

# How to test changes in the EMR cluster

### FileTrek/InterSalt deployment scripts

This script describes the process to set up and deploy the cloud cluster and for more info follow the below links

[To update the spark classpath and s3 jars on the EMR nodes](https://github.com/FileTrek/Intersalt/blob/5.7.0_cloud/docs/ping-cluster-deployment.md)

[Intersalt](https://github.com/FileTrek/Intersalt)

### Test case:
Run the analytics with this custom version of the phoenix-spark jar file. Analytics should run without any issue.
